### PR TITLE
Backport PR 31

### DIFF
--- a/proprietary-files-vendor.txt
+++ b/proprietary-files-vendor.txt
@@ -187,7 +187,6 @@ vendor/etc/graphite_ipc_platform_info.xml
 vendor/etc/listen_platform_info.xml
 vendor/etc/mixer_paths.xml
 vendor/etc/mixer_paths_tasha.xml
-vendor/etc/r_submix_audio_policy_configuration.xml
 vendor/etc/sound_trigger_mixer_paths.xml
 vendor/etc/sound_trigger_platform_info.xml
 vendor/etc/usb_audio_policy_configuration.xml

--- a/proprietary-files-vendor.txt
+++ b/proprietary-files-vendor.txt
@@ -177,7 +177,6 @@ vendor/lib64/soundfx/libqcvirt.so
 # AUDIO_CONFIGS
 vendor/etc/a2dp_audio_policy_configuration.xml
 vendor/etc/audio_effects.xml
-vendor/etc/audio_output_policy.conf
 vendor/etc/audio_platform_info.xml
 vendor/etc/audio_policy_volumes.xml
 vendor/etc/audio_tuning_mixer.txt 

--- a/proprietary-files-vendor.txt
+++ b/proprietary-files-vendor.txt
@@ -1345,11 +1345,6 @@ vendor/lib64/sensor_calibrate.so
 vendor/lib64/sensors.finger-pickup.so
 vendor/lib64/sensors.ssc.so
 
-# SSR (subsystem restart)
-vendor/bin/ssr_diag
-vendor/bin/ssr_setup
-vendor/bin/subsystem_ramdump
-
 # TAD - from tama - 52.1.A.3.49
 vendor/bin/tad|0fe3daaa4a4dace32944ebb8daf52fdffdcfac8a
 

--- a/proprietary-files-vendor.txt
+++ b/proprietary-files-vendor.txt
@@ -824,14 +824,6 @@ vendor/lib64/lib_fpc_tac_shared.so
 vendor/lib64/com.fingerprints.extension@1.0.so
 
 # IDD
-vendor/bin/hw/vendor.semc.system.idd@1.0-service
-vendor/bin/idd-logreader
-vendor/bin/iddd
-vendor/etc/idd.conf
-vendor/etc/iddd.conf
-vendor/etc/init/vendor.semc.system.idd@1.0-service.rc
-vendor/etc/security/idd_config.pem
-vendor/etc/security/idd_report.pem
 vendor/lib/libidd.so
 vendor/lib/libprotobuf-c.so
 vendor/lib/vendor.semc.system.idd@1.0.so

--- a/proprietary-files-vendor.txt
+++ b/proprietary-files-vendor.txt
@@ -1404,7 +1404,7 @@ vendor/lib64/vendor.qti.hardware.improvetouch.touchcompanion@1.0.so
 vendor/bin/taimport_vendor
 vendor/bin/ta_qmi_service
 vendor/etc/init/init.taqmi.rc
-vendor/etc/init/taimport_vendor.rc
+vendor/etc/init/taimport_vendor.rc|0551b8c8b99c2182d8504fca241f382aa0c3de2d
 -vendor/lib/libmiscta.so
 -vendor/lib/libta.so
 -vendor/lib64/libmiscta.so

--- a/proprietary-files-vendor.txt
+++ b/proprietary-files-vendor.txt
@@ -885,7 +885,6 @@ vendor/lib64/vendor.semc.hardware.light@1.0.so
 # MEDIA
 vendor/etc/seccomp_policy/mediacodec.policy
 vendor/etc/seccomp_policy/mediaextractor.policy
-vendor/etc/media_profiles_V1_0.xml|7e8b7c97c8c79fbe9d9ef84428c42803d318e39b
 vendor/lib/libAlacSwDec.so
 vendor/lib/libApeSwDec.so
 vendor/lib/libFlacSwDec.so

--- a/proprietary-files-vendor.txt
+++ b/proprietary-files-vendor.txt
@@ -1121,10 +1121,8 @@ vendor/lib64/libkeymasterutils.so
 vendor/bin/energy-awareness|468d5fc803ac4a97ee23f8908feaadd015f96f77
 vendor/lib/vendor.qti.hardware.perf@1.0.so|8fb84f6353794e276027a24b7198bdccd26cc327
 vendor/lib/vendor.qti.hardware.perf@2.0.so|d5a9678f2583b616f55d2eb9643b85cb13f8dd06
-vendor/lib/libqti-perfd-client.so|2c488bc54a6ba25c6dab51dcb538efe6b0ae2b86
 vendor/lib64/vendor.qti.hardware.perf@1.0.so|afd9b13e1a08a77afa0603731c90e58c4cc570f9
 vendor/lib64/vendor.qti.hardware.perf@2.0.so|8330f1eb40d6288641a86afae4dd5ba8a154533b
-vendor/lib64/libqti-perfd-client.so|0c2b82b5e5df6e0efb03ace4a259eb63487dd2b6
 
 # QTI_QTEECONNECTOR
 vendor/bin/hw/vendor.qti.hardware.qteeconnector@1.0-service

--- a/proprietary-files-vendor.txt
+++ b/proprietary-files-vendor.txt
@@ -1014,9 +1014,7 @@ vendor/lib64/hw/com.qualcomm.qti.ant@1.0-impl.so
 vendor/bin/hw/android.hardware.bluetooth@1.0-service-qti
 vendor/etc/init/android.hardware.bluetooth@1.0-service-qti.rc
 vendor/lib/hw/android.hardware.bluetooth@1.0-impl-qti.so
-vendor/lib/hw/com.qualcomm.qti.bluetooth_audio@1.0-impl.so
 vendor/lib64/hw/android.hardware.bluetooth@1.0-impl-qti.so
-vendor/lib64/hw/com.qualcomm.qti.bluetooth_audio@1.0-impl.so
 
 # QTI_ESEPOWERMANAGER
 vendor/bin/hw/vendor.qti.esepowermanager@1.0-service

--- a/proprietary-files-vendor.txt
+++ b/proprietary-files-vendor.txt
@@ -1119,10 +1119,6 @@ vendor/lib64/libkeymasterutils.so
 
 # QTI_PERF - from cheeseburger - QKQ1.191014.012
 vendor/bin/energy-awareness|468d5fc803ac4a97ee23f8908feaadd015f96f77
-vendor/lib/vendor.qti.hardware.perf@1.0.so|8fb84f6353794e276027a24b7198bdccd26cc327
-vendor/lib/vendor.qti.hardware.perf@2.0.so|d5a9678f2583b616f55d2eb9643b85cb13f8dd06
-vendor/lib64/vendor.qti.hardware.perf@1.0.so|afd9b13e1a08a77afa0603731c90e58c4cc570f9
-vendor/lib64/vendor.qti.hardware.perf@2.0.so|8330f1eb40d6288641a86afae4dd5ba8a154533b
 
 # QTI_QTEECONNECTOR
 vendor/bin/hw/vendor.qti.hardware.qteeconnector@1.0-service

--- a/proprietary-files-vendor.txt
+++ b/proprietary-files-vendor.txt
@@ -885,7 +885,6 @@ vendor/lib64/vendor.semc.hardware.light@1.0.so
 # MEDIA
 vendor/etc/seccomp_policy/mediacodec.policy
 vendor/etc/seccomp_policy/mediaextractor.policy
-vendor/etc/media_codecs_performance.xml
 vendor/etc/media_profiles_V1_0.xml|7e8b7c97c8c79fbe9d9ef84428c42803d318e39b
 vendor/lib/libAlacSwDec.so
 vendor/lib/libApeSwDec.so

--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -244,18 +244,12 @@ etc/firmware/tztpm.b07
 etc/firmware/tztpm.mdt
 
 # FRAMEWORK_DEPENDENCIES
-etc/permissions/com.sonyericsson.idd.xml
 etc/permissions/com.sonymobile.getmore.api.xml
-framework/com.sonyericsson.idd_impl.jar
 framework/com.sonymobile.getmore.api.jar
 
 # GRAPHICS
 lib/libOpenCL_system.so
 lib64/libOpenCL_system.so
-
-# IDD
-bin/startup-logger
-etc/init/startup-logger.rc
 
 # LIGHT
 lib/vendor.semc.hardware.light@1.0.so

--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -588,18 +588,6 @@ lib64/libsensor1.so
 lib64/libsensor_reg.so
 lib64/libsensor_test.so
 
-# SSR
-bin/bt_ssr_dumper
-bin/ssr_dumper
-etc/ssrdumper_config.xml
-etc/ssrdumper_target.xml
-lib/libdumpframework.so
-lib/libsnappy.so
-lib/libtlcore.so
-lib64/libdumpframework.so
-lib64/libsnappy.so
-lib64/libtlcore.so
-
 # TOUCH
 somc/touch/images/big_touch.png:vendor/sony/touch/images/big_touch.png
 somc/touch/images/splash.png:vendor/sony/touch/images/splash.png

--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -533,12 +533,6 @@ lib64/vendor.qti.ims.callinfo@1.0.so:product/lib64/vendor.qti.ims.callinfo@1.0.s
 lib64/vendor.qti.imsrtpservice@1.0.so:product/lib64/vendor.qti.imsrtpservice@1.0.so
 -priv-app/ims/ims.apk:product/priv-app/ims/ims.apk
 
-# QTI_PERF - from cheeseburger - QKQ1.191014.012
-lib/vendor.qti.hardware.perf@1.0.so|14433f3baf7e760208f3e6ebbcb5583c5cfbf91c
-lib/vendor.qti.hardware.perf@2.0.so|67fbeed3fce2a6521f9c1d39b6cab1cd1550bd2a
-lib64/vendor.qti.hardware.perf@1.0.so|125a5c14b4e768ef7ce1d89abee9b2421f17b7ba
-lib64/vendor.qti.hardware.perf@2.0.so|d4f082dcf0fedec3376144f91bc163c3c863ebd4
-
 # QTI_QTEECONNECTOR
 lib/vendor.qti.hardware.qteeconnector@1.0.so
 lib64/vendor.qti.hardware.qteeconnector@1.0.so

--- a/vendor.prop
+++ b/vendor.prop
@@ -3,5 +3,3 @@ vendor.display.hwc_disable_hdr=1
 
 # Radio
 persist.vendor.radio.block_allow_data=1
-
-ro.vendor.extension_library=libqti-perfd-client.so


### PR DESCRIPTION
Backport of https://github.com/whatawurst/android_device_sony_lilac/pull/31

Skipped: 
- lilac: proprietary: Drop pre-built gralloc and libqdMetaData