### PR TITLE
lilac: proprietary: Drop pre-built gralloc and libqdMetaData

### DIFF
--- a/proprietary-files-vendor.txt
+++ b/proprietary-files-vendor.txt
@@ -641,14 +641,6 @@ vendor/lib64/vendor.qti.hardware.qdutils_disp@1.0.so
 vendor/lib/libsdedrm.so|089227205f43da5a974897f680238270ee49f562
 vendor/lib64/libsdedrm.so|f007903083a95cba32372df7404cbf0d39abe2a7
 
-# DISPLAY_GRALLOC
-vendor/lib/hw/gralloc.default.so|f245d2a6624e0f0fa501add5f405ffe811a4ef2c
-vendor/lib/hw/gralloc.msm8998.so|52dec8a00298a3096cfac7fa62ef10efd641b76e
-vendor/lib/libqdMetaData.so|19dbe9a16251fcf21b6c65198acbe85ab0bbbd8d
-vendor/lib64/hw/gralloc.default.so|7d9ed576cd15fb199e13203a391df4747b72454f
-vendor/lib64/hw/gralloc.msm8998.so|e0da90c598f44454fd6077e6fa84092361c11e83
-vendor/lib64/libqdMetaData.so|84cac8c2b78cca0988fbf53b3b670bf1bc11a635
-
 # DISPLAY_HDR - from cheeseburger - QKQ1.191014.012
 vendor/lib/libhdr_tm.so|e69119603bff4a039242eead65279b3faf29ffa0
 vendor/lib64/libhdr_tm.so|ac4c943ba0c9793e53fc0b4eecf78ebb90eb28bf


### PR DESCRIPTION
We are now building from in-tree display hal.

Change-Id: I247196865af3416af84f9247d327a067d4ca340b