### PR TITLE
Use Clang 12.0.7 for LOS 17

### DIFF
--- a/patches/disable-tidy-check-in-idmap2.patch
+++ b/patches/disable-tidy-check-in-idmap2.patch
@@ -1,0 +1,14 @@
+# PWD: frameworks/base
+diff --git a/cmds/idmap2/Android.bp b/cmds/idmap2/Android.bp
+index 18d56fa87cca..913d2a73f17f 100644
+--- a/cmds/idmap2/Android.bp
++++ b/cmds/idmap2/Android.bp
+@@ -21,6 +21,8 @@ cc_defaults {
+         "android-*",
+         "misc-*",
+         "readability-*",
++        "-misc-no-recursion",
++        "-readability-function-cognitive-complexity",
+     ],
+     tidy_flags: [
+         "-system-headers",

--- a/patches/disable-tidy-in-android-clat.patch
+++ b/patches/disable-tidy-in-android-clat.patch
@@ -1,0 +1,14 @@
+# PWD: external/android-clat
+diff --git a/Android.bp b/Android.bp
+index b495dac..6eb234f 100644
+--- a/Android.bp
++++ b/Android.bp
+@@ -57,7 +57,7 @@ cc_binary {
+     // Only enable clang-tidy for the daemon, not the tests, because enabling it for the
+     // tests substantially increases build/compile cycle times and doesn't really provide a
+     // security benefit.
+-    tidy: true,
++    tidy: false,
+     tidy_checks: [
+         "-*",
+         "cert-*",

--- a/patches/fix-count-template.patch
+++ b/patches/fix-count-template.patch
@@ -1,0 +1,31 @@
+# PWD: system/security
+commit 8b68026faa37704d7622df6f38cfca52b1eead70
+Author: Stephen Hines <srhines@google.com>
+Date:   Wed Jul 15 18:12:36 2020 -0700
+
+    Switch from `count` to `N` for template due to ambiguity with `std::count`
+    
+    Recent versions of Clang will flag this use of `count` in namespace
+    `std` as ambiguous due to the existence of `std::count`. To remove this
+    problem, we can switch to the commonly used `N` for array sizes.
+    
+    Bug: http://b/155835175
+    Test: m with aosp_blueline
+    Change-Id: I983180b6e2e94dadb095f531e13ea415468ee104
+
+diff --git a/keystore/KeyStore.h b/keystore/KeyStore.h
+index 0027ec8..7841a80 100644
+--- a/keystore/KeyStore.h
++++ b/keystore/KeyStore.h
+@@ -62,9 +62,9 @@ template <typename T, size_t count> class Devices : public std::array<T, count>
+ }  // namespace keystore
+ 
+ namespace std {
+-template <typename T, size_t count> struct tuple_size<keystore::Devices<T, count>> {
++template <typename T, size_t N> struct tuple_size<keystore::Devices<T, N>> {
+   public:
+-    static constexpr size_t value = std::tuple_size<std::array<T, count>>::value;
++    static constexpr size_t value = std::tuple_size<std::array<T, N>>::value;
+ };
+ }  // namespace std
+ 

--- a/patches/fix-deprecated-inst-strlen.patch
+++ b/patches/fix-deprecated-inst-strlen.patch
@@ -1,0 +1,26 @@
+# PWD: bionic
+commit 5cb4d9cef97a30ada3edc10b6aee00ab044f790c
+Author: Chih-Hung Hsieh <chh@google.com>
+Date:   Wed Feb 3 15:15:52 2021 -0800
+
+    Fix "deprecated instruction in IT block" warning
+    
+    Bug: 179266557
+    Test: make with new clang compiler
+    Change-Id: I963609861659cbb2be8ed467654109938185c747
+
+diff --git a/libc/arch-arm/generic/bionic/strlen.c b/libc/arch-arm/generic/bionic/strlen.c
+index 43d9e514c..a6fde8b5f 100644
+--- a/libc/arch-arm/generic/bionic/strlen.c
++++ b/libc/arch-arm/generic/bionic/strlen.c
+@@ -116,8 +116,8 @@ size_t strlen_generic(const char *s)
+         "beq     2f                         \n"
+         "add     %[l], %[l], #1             \n"
+         "tst     %[v], #0xFF0000            \n"
+-        "it      ne                         \n"
+-        "addne   %[l], %[l], #1             \n"
++        "beq     2f                         \n"
++        "add     %[l], %[l], #1             \n"
+         "2:                                 \n"
+         : [l]"=&r"(l), [v]"=&r"(v), [t]"=&r"(t), [s]"=&r"(u.b)
+         : "%[l]"(l), "%[s]"(u.b), [mask]"r"(0x80808080UL)

--- a/patches/fix-dtor-alias.patch
+++ b/patches/fix-dtor-alias.patch
@@ -1,0 +1,31 @@
+# PWD: external/perfetto
+commit 46f0abc66c1d78c60a0415c5cb46852ef3bfa9bb
+Author: Nico Weber <thakis@chromium.org>
+Date:   Sat Feb 8 21:26:53 2020 -0500
+
+    Fix compile error emitted by trunk clang
+    
+    ../../third_party/perfetto/src/tracing/core/virtual_destructors.cc:33:35:
+    error: destructor cannot be declared using a type alias
+        'perfetto::TracingService::ConsumerEndpoint' (aka
+        'perfetto::ConsumerEndpoint') of the class name
+    TracingService::ConsumerEndpoint::~ConsumerEndpoint() = default;
+    
+    Bug: chromium:1050372
+    Change-Id: Icc1a8cca06b72ee3322924dc0825ebb62086f730
+
+diff --git a/src/tracing/core/virtual_destructors.cc b/src/tracing/core/virtual_destructors.cc
+index aa7345385..6682a6878 100644
+--- a/src/tracing/core/virtual_destructors.cc
++++ b/src/tracing/core/virtual_destructors.cc
+@@ -30,8 +30,8 @@ namespace perfetto {
+ Consumer::~Consumer() = default;
+ Producer::~Producer() = default;
+ TracingService::~TracingService() = default;
+-TracingService::ConsumerEndpoint::~ConsumerEndpoint() = default;
+-TracingService::ProducerEndpoint::~ProducerEndpoint() = default;
++ConsumerEndpoint::~ConsumerEndpoint() = default;
++ProducerEndpoint::~ProducerEndpoint() = default;
+ SharedMemory::~SharedMemory() = default;
+ SharedMemory::Factory::~Factory() = default;
+ SharedMemoryArbiter::~SharedMemoryArbiter() = default;

--- a/patches/fix-duplicate-yylloc.patch
+++ b/patches/fix-duplicate-yylloc.patch
@@ -1,0 +1,45 @@
+# PWD: external/dtc
+commit 0e9225eb0dfec51def612b928d2f1836b092bc7e
+Author: Dirk Mueller <dmueller@suse.com>
+Date:   Tue Jan 14 18:53:41 2020 +0100
+
+    Remove redundant YYLOC global declaration
+    
+    gcc 10 will default to -fno-common, which causes this error at link
+    time:
+    
+      (.text+0x0): multiple definition of `yylloc'; dtc-lexer.lex.o (symbol from plugin):(.text+0x0): first defined here
+    
+    This is because both dtc-lexer as well as dtc-parser define the same
+    global symbol yyloc. Before with -fcommon those were merged into one
+    defintion. The proper solution would be to to mark this as "extern",
+    however that leads to:
+    
+      dtc-lexer.l:26:16: error: redundant redeclaration of 'yylloc' [-Werror=redundant-decls]
+       26 | extern YYLTYPE yylloc;
+          |                ^~~~~~
+    In file included from dtc-lexer.l:24:
+    dtc-parser.tab.h:127:16: note: previous declaration of 'yylloc' was here
+      127 | extern YYLTYPE yylloc;
+          |                ^~~~~~
+    cc1: all warnings being treated as errors
+    
+    which means the declaration is completely redundant and can just be
+    dropped.
+    
+    Signed-off-by: Dirk Mueller <dmueller@suse.com>
+    Message-Id: <20200114175341.2994-1-dmueller@suse.com>
+    Signed-off-by: David Gibson <david@gibson.dropbear.id.au>
+
+diff --git a/dtc-lexer.l b/dtc-lexer.l
+index 5c6c3fd..b3b7270 100644
+--- a/dtc-lexer.l
++++ b/dtc-lexer.l
+@@ -23,7 +23,6 @@ LINECOMMENT	"//".*\n
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */

--- a/patches/fix-execute-only-flag.patch
+++ b/patches/fix-execute-only-flag.patch
@@ -1,0 +1,14 @@
+# PWD: build/make
+diff --git a/core/binary.mk b/core/binary.mk
+index d4f0476c8c..7986845789 100644
+--- a/core/binary.mk
++++ b/core/binary.mk
+@@ -119,7 +119,7 @@ ifneq ($(strip $(ENABLE_XOM)),false)
+     ifeq ($(strip $(my_xom)),true)
+       ifeq (arm64,$(TARGET_$(LOCAL_2ND_ARCH_VAR_PREFIX)ARCH))
+         ifeq ($(my_use_clang_lld),true)
+-          my_ldflags += -Wl,-execute-only
++          my_ldflags += -Wl,--execute-only
+         endif
+       endif
+     endif

--- a/patches/fix-execute-only-flag2.patch
+++ b/patches/fix-execute-only-flag2.patch
@@ -1,0 +1,14 @@
+# PWD: build/soong
+diff --git a/cc/xom.go b/cc/xom.go
+index 9337990f8..30e3f52b8 100644
+--- a/cc/xom.go
++++ b/cc/xom.go
+@@ -68,7 +68,7 @@ func (xom *xom) flags(ctx ModuleContext, flags Flags) Flags {
+ 	if !disableXom || (xom.Properties.Xom != nil && *xom.Properties.Xom) {
+ 		// XOM is only supported on AArch64 when using lld.
+ 		if ctx.Arch().ArchType == android.Arm64 && ctx.useClangLld(ctx) {
+-			flags.LdFlags = append(flags.LdFlags, "-Wl,-execute-only")
++			flags.LdFlags = append(flags.LdFlags, "-Wl,--execute-only")
+ 		}
+ 	}
+ 

--- a/patches/fix-ignored-pragma-warning.patch
+++ b/patches/fix-ignored-pragma-warning.patch
@@ -1,0 +1,28 @@
+# PWD: bionic
+commit 444e2f69e95e25a206efb120dff3d4dde637746b
+Author: Chih-Hung Hsieh <chh@google.com>
+Date:   Tue Jan 26 14:02:23 2021 -0800
+
+    Add -Wno-ignored-pragmas.
+    
+    * https://reviews.llvm.org/D90316 changed warning on
+      FENV_ACCESS pragma from unknown to ignored.
+      Existing -Wno-unknown-pragmas cannot suppress the new
+      -Wignored-pragmas.
+    
+    Bug: 178516148
+    Test: make with WITH_TIDY=1
+    Change-Id: I783feef35324ef43946efca844cd944410875bfa
+
+diff --git a/libm/Android.bp b/libm/Android.bp
+index 735b1cf71..723d126dc 100644
+--- a/libm/Android.bp
++++ b/libm/Android.bp
+@@ -475,6 +475,7 @@ cc_library {
+         "-fno-math-errno",
+         "-Wall",
+         "-Werror",
++        "-Wno-ignored-pragmas",
+         "-Wno-missing-braces",
+         "-Wno-parentheses",
+         "-Wno-sign-compare",

--- a/patches/fix-ion-ptr-convert.patch
+++ b/patches/fix-ion-ptr-convert.patch
@@ -1,0 +1,28 @@
+# PWD: system/core/libion
+commit 4f98785e4debdc8090fc0d5bfda2574b60f6ce46
+Author: Stephen Hines <srhines@google.com>
+Date:   Tue Jul 14 12:21:26 2020 -0700
+
+    Switch to using 0 instead of NULL for a void* -> int cast
+    
+    system/memory/libion/ion.c:51:32: error: cast to smaller integer type 'ion_user_handle_t' (aka 'int') from 'void *' [-Werror,-Wvoid-pointer-to-int-cast]
+            int err = ion_free(fd, (ion_user_handle_t)NULL);
+                                   ^~~~~~~~~~~~~~~~~~~~~~~
+    
+    Bug: http://b/155835175
+    Test: m with aosp_blueline
+    Change-Id: I0d663ddbc245764b469c4f589831586ea7e55148
+
+diff --git a/ion.c b/ion.c
+index 07b4caf..8fdbb60 100644
+--- a/ion.c
++++ b/ion.c
+@@ -48,7 +48,7 @@ int ion_is_legacy(int fd) {
+           * Check for FREE IOCTL here; it is available only in the old
+           * kernels, not the new ones.
+           */
+-        int err = ion_free(fd, (ion_user_handle_t)NULL);
++        int err = ion_free(fd, (ion_user_handle_t)0);
+         version = (err == -ENOTTY) ? ION_VERSION_MODERN : ION_VERSION_LEGACY;
+         atomic_store_explicit(&g_ion_version, version, memory_order_release);
+     }

--- a/patches/fix-wformat.patch
+++ b/patches/fix-wformat.patch
@@ -1,0 +1,29 @@
+# PWD: hardware/ril
+commit b2fbf5c3b443ed3eb5daaf8f8585f8d06dc111a0
+Author: Stephen Hines <srhines@google.com>
+Date:   Mon Aug 17 23:47:06 2020 -0700
+
+    Fix -Wformat error with explicit void* -> char* cast.
+    
+    hardware/ril/reference-ril/reference-ril.c:1841:46: error: format specifies type 'char *' but the argument has type 'void *' [-Werror,-Wformat]
+        snprintf(cmd, sizeof(cmd), "AT+CCHO=%s", data);
+                                            ~~   ^~~~
+    
+    Bug: http://b/155835175
+    Test: m
+    Change-Id: I7fd819c6c452b56aae15429344320c4cdaed702c
+    (cherry picked from commit 363b39bbc81a3269fe75bd5f505289f85d05792e)
+
+diff --git a/reference-ril/reference-ril.c b/reference-ril/reference-ril.c
+index 084c4ad..430bc9b 100644
+--- a/reference-ril/reference-ril.c
++++ b/reference-ril/reference-ril.c
+@@ -1838,7 +1838,7 @@ static void requestSimOpenChannel(void *data, size_t datalen, RIL_Token t)
+         return;
+     }
+ 
+-    snprintf(cmd, sizeof(cmd), "AT+CCHO=%s", data);
++    snprintf(cmd, sizeof(cmd), "AT+CCHO=%s", (char*) data);
+ 
+     err = at_send_command_numeric(cmd, &p_response);
+     if (err < 0 || p_response == NULL || p_response->success == 0) {

--- a/patches/fix-wno-error.patch
+++ b/patches/fix-wno-error.patch
@@ -1,0 +1,36 @@
+# PWD: external/wpa_supplicant_8
+diff --git a/hostapd/Android.mk b/hostapd/Android.mk
+index df3542ae..7c5f7138 100644
+--- a/hostapd/Android.mk
++++ b/hostapd/Android.mk
+@@ -27,7 +27,7 @@ L_CFLAGS += -DANDROID_LOG_NAME=\"hostapd\"
+ L_CFLAGS += -Wall -Werror
+ 
+ # TODO: move off readdir_r upstream, pull fix back (http://b/72326431).
+-L_CFLAGS += -Wno-error-deprecated-declarations
++L_CFLAGS += -Wno-deprecated-declarations
+ 
+ # Disable unused parameter warnings
+ L_CFLAGS += -Wno-unused-parameter
+diff --git a/wpa_supplicant/Android.mk b/wpa_supplicant/Android.mk
+index 8bcd7efe..a446c970 100644
+--- a/wpa_supplicant/Android.mk
++++ b/wpa_supplicant/Android.mk
+@@ -29,7 +29,7 @@ L_CFLAGS += -DANDROID_LOG_NAME=\"wpa_supplicant\"
+ L_CFLAGS += -Wall -Werror
+ 
+ # Keep sometimes uninitialized warnings
+-L_CFLAGS += -Wno-error-sometimes-uninitialized
++L_CFLAGS += -Wno-sometimes-uninitialized
+ 
+ # Disable incompatible pointer type warnings
+ L_CFLAGS += -Wno-incompatible-pointer-types
+@@ -42,7 +42,7 @@ L_CFLAGS += -Wno-parentheses-equality
+ L_CFLAGS += -Wno-sign-compare
+ 
+ # TODO: move off readdir_r upstream, pull fix back (http://b/72326431).
+-L_CFLAGS += -Wno-error-deprecated-declarations
++L_CFLAGS += -Wno-deprecated-declarations
+ 
+ # Disable unused function warnings
+ L_CFLAGS += -Wno-unused-function

--- a/patches/remove-jni-stack-check.patch
+++ b/patches/remove-jni-stack-check.patch
@@ -1,0 +1,73 @@
+# PWD: art
+
+Fix warning on __builtin_return_address
+See 01ecfa1c31282e12b18df5b2f555898a0c3a2e35 & 8f0eb966a2ba14717687b7282e96c8a5c64f5300
+diff --git a/runtime/jni/jni_internal.cc b/runtime/jni/jni_internal.cc
+index 1055057fc7..bb5b84034f 100644
+--- a/runtime/jni/jni_internal.cc
++++ b/runtime/jni/jni_internal.cc
+@@ -162,20 +162,6 @@ size_t VisitModifiedUtf8Chars(const char* utf8, size_t byte_count, GoodFunc good
+   return len;
+ }
+ 
+-static constexpr size_t kMaxReturnAddressDepth = 4;
+-
+-inline void* GetReturnAddress(size_t depth) {
+-  DCHECK_LT(depth, kMaxReturnAddressDepth);
+-  switch (depth) {
+-    case 0u: return __builtin_return_address(0);
+-    case 1u: return __builtin_return_address(1);
+-    case 2u: return __builtin_return_address(2);
+-    case 3u: return __builtin_return_address(3);
+-    default:
+-      return nullptr;
+-  }
+-}
+-
+ enum class SharedObjectKind {
+   kRuntime = 0,
+   kApexModule = 1,
+@@ -315,42 +301,15 @@ class CodeRangeCache final {
+   DISALLOW_COPY_AND_ASSIGN(CodeRangeCache);
+ };
+ 
+-// Whitelisted native callers can resolve method and field id's via JNI. Check the first caller
+-// outside of the JNI library who will have called Get(Static)?(Field|Member)ID(). The presence of
+-// checked JNI means we need to walk frames as the internal methods can be called directly from an
+-// external shared-object or indirectly (via checked JNI) from an external shared-object.
+-static inline bool IsWhitelistedNativeCaller() {
+-  if (!art::kIsTargetBuild) {
+-    return false;
+-  }
+-  for (size_t i = 0; i < kMaxReturnAddressDepth; ++i) {
+-    void* return_address = GetReturnAddress(i);
+-    if (return_address == nullptr) {
+-      return false;
+-    }
+-    SharedObjectKind kind = CodeRangeCache::GetSingleton().GetSharedObjectKind(return_address);
+-    if (kind != SharedObjectKind::kRuntime) {
+-      return kind == SharedObjectKind::kApexModule;
+-    }
+-  }
+-  return false;
+-}
+-
+ }  // namespace
+ 
+ // Consider turning this on when there is errors which could be related to JNI array copies such as
+ // things not rendering correctly. E.g. b/16858794
+ static constexpr bool kWarnJniAbort = false;
+ 
+-// Disable native JNI checking pending stack walk re-evaluation (b/136276414).
+-static constexpr bool kNativeJniCheckEnabled = false;
+-
+ template<typename T>
+ ALWAYS_INLINE static bool ShouldDenyAccessToMember(T* member, Thread* self)
+     REQUIRES_SHARED(Locks::mutator_lock_) {
+-  if (kNativeJniCheckEnabled && IsWhitelistedNativeCaller()) {
+-    return false;
+-  }
+   return hiddenapi::ShouldDenyAccessToMember(
+       member,
+       [&]() REQUIRES_SHARED(Locks::mutator_lock_) {
+

--- a/patches/update-clang.patch
+++ b/patches/update-clang.patch
@@ -1,7 +1,6 @@
 # PWD: build/soong
-
 diff --git a/Android.bp b/Android.bp
-index b07fbe57..5b363b3d 100644
+index b07fbe57a..5b363b3d4 100644
 --- a/Android.bp
 +++ b/Android.bp
 @@ -543,7 +543,6 @@ toolchain_library {
@@ -21,7 +20,7 @@ index b07fbe57..5b363b3d 100644
  }
  
 diff --git a/cc/binary.go b/cc/binary.go
-index 2a6ceb82..bff61b6b 100644
+index 2a6ceb821..bff61b6bf 100644
 --- a/cc/binary.go
 +++ b/cc/binary.go
 @@ -326,7 +326,7 @@ func (binary *binaryDecorator) link(ctx ModuleContext,
@@ -43,7 +42,7 @@ index 2a6ceb82..bff61b6b 100644
  
  			binary.injectVersionSymbol(ctx, outputFile, versionedOutputFile)
 diff --git a/cc/builder.go b/cc/builder.go
-index a9ee4e92..d7b51051 100644
+index a9ee4e92c..d7b510516 100644
 --- a/cc/builder.go
 +++ b/cc/builder.go
 @@ -277,11 +277,12 @@ type builderFlags struct {
@@ -75,10 +74,17 @@ index a9ee4e92..d7b51051 100644
  		args += " --use-gnu-strip"
  	}
 diff --git a/cc/config/clang.go b/cc/config/clang.go
-index a87d5695..6f9ee4ab 100644
+index a87d56956..f8093997e 100644
 --- a/cc/config/clang.go
 +++ b/cc/config/clang.go
-@@ -48,6 +48,8 @@ var ClangUnknownCflags = sorted([]string{
+@@ -41,13 +41,14 @@ var ClangUnknownCflags = sorted([]string{
+ 	"-Wno-literal-suffix",
+ 	"-Wno-maybe-uninitialized",
+ 	"-Wno-old-style-declaration",
+-	"-Wno-psabi",
+ 	"-Wno-unused-but-set-parameter",
+ 	"-Wno-unused-but-set-variable",
+ 	"-Wno-unused-local-typedefs",
  	"-Wunused-but-set-parameter",
  	"-Wunused-but-set-variable",
  	"-fdiagnostics-color",
@@ -87,17 +93,19 @@ index a87d5695..6f9ee4ab 100644
  
  	// arm + arm64 + mips + mips64
  	"-fgcse-after-reload",
-@@ -101,9 +103,6 @@ func init() {
+@@ -101,8 +102,9 @@ func init() {
  		// not emit the table by default on Android since NDK still uses GNU binutils.
  		"-faddrsig",
  
 -		// -Wimplicit-fallthrough is not enabled by -Wall.
 -		"-Wimplicit-fallthrough",
--
++		// Turn on -fcommon explicitly, since Clang now defaults to -fno-common. The cleanup bug
++		// tracking this is http://b/151457797.
++		"-fcommon",
+ 
  		// Help catch common 32/64-bit errors.
  		"-Werror=int-conversion",
- 
-@@ -124,9 +123,6 @@ func init() {
+@@ -124,9 +126,6 @@ func init() {
  		// color codes if it is not running in a terminal.
  		"-fcolor-diagnostics",
  
@@ -107,7 +115,7 @@ index a87d5695..6f9ee4ab 100644
  		// Warnings from clang-7.0
  		"-Wno-sign-compare",
  
-@@ -136,9 +132,17 @@ func init() {
+@@ -136,9 +135,21 @@ func init() {
  		// Disable -Winconsistent-missing-override until we can clean up the existing
  		// codebase for it.
  		"-Wno-inconsistent-missing-override",
@@ -116,7 +124,11 @@ index a87d5695..6f9ee4ab 100644
 +		// Warnings from clang-10
 +		// Nested and array designated initialization is nice to have.
 +		"-Wno-c99-designator",
-+}, " "))
++		// Warnings from clang-12
++		"-Wno-gnu-folding-constant",
++		"-Wno-suggest-override",
++		"-Wno-suggest-destructor-override",
++       }, " "))
  
  	pctx.StaticVariable("ClangExtraCppflags", strings.Join([]string{
 +		// -Wimplicit-fallthrough is not enabled by -Wall.
@@ -126,7 +138,7 @@ index a87d5695..6f9ee4ab 100644
  		// Enable clang's thread-safety annotations in libcxx.
  		// Turn off -Wthread-safety-negative, to avoid breaking projects that use -Weverything.
  		"-D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS",
-@@ -171,8 +175,29 @@ func init() {
+@@ -171,8 +182,33 @@ func init() {
  		// compatibility.
  		"-Wno-c++98-compat-extra-semi",
  
@@ -153,10 +165,14 @@ index a87d5695..6f9ee4ab 100644
 +		"-Wno-enum-enum-conversion",                 // http://b/154138986
 +		"-Wno-enum-float-conversion",                // http://b/154255917
 +		"-Wno-pessimizing-move",                     // http://b/154270751
++		// New warnings to be fixed after clang-r399163
++               "-Wno-non-c-typedef-for-linkage", // http://b/161304145
++               // New warnings to be fixed after clang-r407598
++               "-Wno-string-concatenation", // http://b/175068488
  	}, " "))
  
  	// Extra cflags for projects under external/ directory to disable warnings that are infeasible
-@@ -188,6 +213,13 @@ func init() {
+@@ -188,6 +224,13 @@ func init() {
  		// Bug: http://b/29823425 Disable -Wnull-dereference until the
  		// new instances detected by this warning are fixed.
  		"-Wno-null-dereference",
@@ -171,22 +187,35 @@ index a87d5695..6f9ee4ab 100644
  }
  
 diff --git a/cc/config/global.go b/cc/config/global.go
-index 7c7b47a5..203ce1a2 100644
+index 7c7b47a51..4ab0871a6 100644
 --- a/cc/config/global.go
 +++ b/cc/config/global.go
-@@ -122,8 +122,8 @@ var (
+@@ -107,6 +107,12 @@ var (
+ 	noOverrideGlobalCflags = []string{
+ 		"-Werror=int-to-pointer-cast",
+ 		"-Werror=pointer-to-int-cast",
++		// http://b/161386391 for -Wno-void-pointer-to-enum-cast
++               "-Wno-void-pointer-to-enum-cast",
++               // http://b/161386391 for -Wno-void-pointer-to-int-cast
++               "-Wno-void-pointer-to-int-cast",
++               // http://b/161386391 for -Wno-pointer-to-int-cast
++               "-Wno-pointer-to-int-cast",
+ 	}
+ 
+ 	IllegalFlags = []string{
+@@ -122,8 +128,8 @@ var (
  
  	// prebuilts/clang default settings.
  	ClangDefaultBase         = "prebuilts/clang/host"
 -	ClangDefaultVersion      = "clang-r353983c1"
 -	ClangDefaultShortVersion = "9.0.3"
-+	ClangDefaultVersion      = "clang-r383902b1"
-+	ClangDefaultShortVersion = "11.0.2"
++	ClangDefaultVersion      = "clang-r416183b1"
++	ClangDefaultShortVersion = "12.0.7"
  
  	// Directories with warnings from Android.bp files.
  	WarningAllowedProjects = []string{
 diff --git a/cc/library.go b/cc/library.go
-index 39f7a724..e28a97c3 100644
+index 39f7a724b..e28a97c37 100644
 --- a/cc/library.go
 +++ b/cc/library.go
 @@ -698,7 +698,7 @@ func (library *libraryDecorator) linkShared(ctx ModuleContext,
@@ -208,7 +237,7 @@ index 39f7a724..e28a97c3 100644
  
  			library.injectVersionSymbol(ctx, outputFile, versionedOutputFile)
 diff --git a/cc/ndk_library.go b/cc/ndk_library.go
-index 7199467b..7fb04ddd 100644
+index 7199467b6..7fb04ddd4 100644
 --- a/cc/ndk_library.go
 +++ b/cc/ndk_library.go
 @@ -256,6 +256,7 @@ func addStubLibraryCompilerFlags(flags Flags) Flags {
@@ -220,7 +249,7 @@ index 7199467b..7fb04ddd 100644
  		"-Wno-invalid-noreturn",
  		"-Wall",
 diff --git a/cc/prebuilt.go b/cc/prebuilt.go
-index 48e46671..f92c50d1 100644
+index 48e466715..f92c50d1e 100644
 --- a/cc/prebuilt.go
 +++ b/cc/prebuilt.go
 @@ -98,7 +98,7 @@ func (p *prebuiltLibraryLinker) link(ctx ModuleContext,
@@ -242,7 +271,7 @@ index 48e46671..f92c50d1 100644
  		}
  
 diff --git a/cc/strip.go b/cc/strip.go
-index 7122585e..7e560ec9 100644
+index 7122585e3..7e560ec9c 100644
 --- a/cc/strip.go
 +++ b/cc/strip.go
 @@ -22,11 +22,11 @@ import (
@@ -301,7 +330,7 @@ index 7122585e..7e560ec9 100644
 +	stripper.strip(ctx, in, out, flags, true)
 +}
 diff --git a/cc/tidy.go b/cc/tidy.go
-index 54553923..ece0acfa 100644
+index 545539232..ece0acfa3 100644
 --- a/cc/tidy.go
 +++ b/cc/tidy.go
 @@ -117,7 +117,18 @@ func (tidy *tidyFeature) flags(ctx ModuleContext, flags Flags) Flags {
@@ -325,7 +354,7 @@ index 54553923..ece0acfa 100644
  	if len(tidy.Properties.Tidy_checks_as_errors) > 0 {
  		tidyChecksAsErrors := "-warnings-as-errors=" + strings.Join(esc(tidy.Properties.Tidy_checks_as_errors), ",")
 diff --git a/cc/toolchain_library.go b/cc/toolchain_library.go
-index 8ab8bc94..f80ac61c 100644
+index 8ab8bc946..f80ac61c2 100644
 --- a/cc/toolchain_library.go
 +++ b/cc/toolchain_library.go
 @@ -83,7 +83,7 @@ func (library *toolchainLibraryDecorator) link(ctx ModuleContext,
@@ -338,7 +367,7 @@ index 8ab8bc94..f80ac61c 100644
  	}
  
 diff --git a/scripts/strip.sh b/scripts/strip.sh
-index 0f77da8a..40f01842 100755
+index 0f77da8a9..40f018425 100755
 --- a/scripts/strip.sh
 +++ b/scripts/strip.sh
 @@ -28,7 +28,7 @@

--- a/patches/update-kernel-clang-for-host-cc.patch
+++ b/patches/update-kernel-clang-for-host-cc.patch
@@ -9,7 +9,7 @@ index 43154d49..ff6b2eef 100644
  endif
  
 -CLANG_PREBUILTS := $(BUILD_TOP)/prebuilts/clang/host/$(HOST_PREBUILT_TAG)/clang-r353983c1
-+CLANG_PREBUILTS := $(BUILD_TOP)/prebuilts/clang/host/$(HOST_PREBUILT_TAG)/clang-r383902b1
++CLANG_PREBUILTS := $(BUILD_TOP)/prebuilts/clang/host/$(HOST_PREBUILT_TAG)/clang-r416183b1
  GCC_PREBUILTS := $(BUILD_TOP)/prebuilts/gcc/$(HOST_OS)-x86
  # arm64 toolchain
  KERNEL_TOOLCHAIN_arm64 := $(GCC_PREBUILTS)/aarch64/aarch64-linux-android-4.9/bin


### PR DESCRIPTION
Using Clang 12 for the kernel but 11.0.2 for other parts requires having 2 clang prebuilds from other branches.
Make it simpler by always using the same Clang.
