### PR TITLE
Revert "Add patch for license support in Soong"

### DIFF
--- a/patches/applyPatches.sh
+++ b/patches/applyPatches.sh
@@ -141,7 +141,6 @@ if [ "$patch_set" = all ]; then
 else
     # v17.1-20221115 fix: ValueError: list.remove(x): x not in list
     applyPatch "$PATCH_ROOT"/fix-custom-apn-script.patch
-    applyPatch "$PATCH_ROOT/asb-2025-03/android_build_soong/0001-BACKPORT-Minimal-license-feature.patch"
     if [ "$patch_set" = minclang ]; then
         # v17.1-20230225 fix: "arm-linux-androidkernel-as" is not allowed
         applyPatch "$PATCH_ROOT"/allow-newer-kernel-clang.patch


### PR DESCRIPTION
This reverts commit 979b570572b4a373ff6f5de478894d0b38584fda. It was unnecessary, since it tried to apply a specific asb-* patch in the minimal and minclang builds, which already get the asb-* patches.

It also broke those builds, because asb-* patches lack the PWD header expected by the applyPatch function.